### PR TITLE
fix/backdrop-module-standards-and-html-form

### DIFF
--- a/tawk_to.admin.inc
+++ b/tawk_to.admin.inc
@@ -23,7 +23,7 @@ function tawk_to_visibility_opts_form($form, &$form_state) {
   $form['visibility_settings'] = array(
     '#type' => 'fieldset',
     '#title' => t('Visibility Settings'),
-    '#description' => t('Define where the tawk.to widget will and won\'t show')
+    '#description' => t('Define where the tawk.to widget will and won\'t show'),
   );
 
   // always display config
@@ -38,7 +38,7 @@ function tawk_to_visibility_opts_form($form, &$form_state) {
     '#description' => t('Select to show on all except the exceptions
     De-select to select the specific pages'),
     '#id' => t('always_display'),
-    '#attributes' => $always_display_attr
+    '#attributes' => $always_display_attr,
   );
 
   // exclude url config
@@ -51,7 +51,7 @@ function tawk_to_visibility_opts_form($form, &$form_state) {
     '#suffix' => '</div>',
     '#id' => t('hide_oncustom'),
     '#default_value' => !is_null($display_opts) && $display_opts->hide_oncustom ?
-      format_multiline_url_paths($display_opts->hide_oncustom) : ''
+      format_multiline_url_paths($display_opts->hide_oncustom) : '',
   );
 
   // show on front page config
@@ -66,7 +66,7 @@ function tawk_to_visibility_opts_form($form, &$form_state) {
     '#prefix' => '<div class="div_show_specific">',
     '#suffix' => '</div>',
     '#id' => t('show_onfrontpage'),
-    '#attributes' => $show_onfrontpage_attr
+    '#attributes' => $show_onfrontpage_attr,
   );
 
   // show on taxonomy config
@@ -82,7 +82,7 @@ function tawk_to_visibility_opts_form($form, &$form_state) {
     '#prefix' => '<div class="div_show_specific">',
     '#suffix' => '</div>',
     '#id' => t('show_ontaxonomy'),
-    '#attributes' => $show_ontaxonomy_attr
+    '#attributes' => $show_ontaxonomy_attr,
   );
 
   // include urls config
@@ -98,14 +98,14 @@ function tawk_to_visibility_opts_form($form, &$form_state) {
     '#prefix' => '<div class="div_show_specific">',
     '#suffix' => '</div>',
     '#id' => t('show_oncustom'),
-    '#default_value' =>  $show_oncustom_default_value
+    '#default_value' =>  $show_oncustom_default_value,
   );
 
   // privacy settings
   $form['privacy_settings'] = array(
     '#type' => 'fieldset',
     '#title' => t('Privacy Settings'),
-    '#description' => t('Define whether or not user information can be used')
+    '#description' => t('Define whether or not user information can be used'),
   );
 
   // enable visitor recognition config
@@ -118,7 +118,7 @@ function tawk_to_visibility_opts_form($form, &$form_state) {
     '#title' => t('Enable visitor recognition'),
     '#description' => t('If selected, name and email address from logged in users will be used to identify the user to you when a chat comes in via tawk.to'),
     '#id' => t('enable_visitor_recognition'),
-    '#attributes' => $enable_visitor_recognition_attr
+    '#attributes' => $enable_visitor_recognition_attr,
   );
 
   // submit button
@@ -143,7 +143,7 @@ function tawk_to_visibility_opts_form_submit($form, &$form_state) {
     'show_onfrontpage' => false,
     'show_ontaxonomy' => false,
     'show_oncustom' => array(),
-    'enable_visitor_recognition' => false
+    'enable_visitor_recognition' => false,
   );
 
   $options = $form_state['values'];

--- a/tawk_to.admin.inc
+++ b/tawk_to.admin.inc
@@ -7,261 +7,186 @@
  */
 
 /**
-* Creates markup for settings page.
-*/
-function tawk_to_render_widget_iframe($base_url, $iframe_url, $widget=array(), $display_opts = null, $sameUser = true)
-{
-  ob_start();
-?>
+ * tawk.to widget visibility options form.
+ */
+function tawk_to_visibility_opts_form($form, &$form_state) {
+  $display_opts = config_get(TAWK_TO_CONFIG_NAME, TAWK_TO_WIDGET_OPTIONS);
 
-<div id="content" >
-  <div class="l-wrapper">
-    <div class="l-wrapper-inner container container-fluid">
-      <div class="l-messages success-message-container" role="status" aria-label="Status messages" id="optionsSuccessMessage">
-        <div class="messages status">
-          <h2 class="element-invisible">Status message</h2>
-          Successfully set widget options to your site
-        </div>
-      </div>
-      <div class="l-page-title">
-        <a id="main-content"></a>
-      </div>
-      <div class="l-content" role="main" aria-label="Main content">
-        <div>
-          <fieldset class="form-wrapper" id="property-widget-settings">
-            <legend><span class="fieldset-legend">Property and Widget Selection</span></legend>
-            <div class="fieldset-wrapper">
-              <div class="fieldset-description">Select the property and widget from your tawk.to account</div>
-              <?php if (!$sameUser) { ?>
-                <div id="widget_already_set" class="alert alert-warning">Notice: Widget already set by other user</div>
-              <?php } ?>
-              <iframe id="tawkIframe" class="tawkto-property-widget-selection" src="" ></iframe>
-              <input type="hidden" class="hidden" name="page_id" value="<?php echo $widget['page_id']?>">
-              <input type="hidden" class="hidden" name="widget_id" value="<?php echo $widget['widget_id']?>">
-            </div>
-          </fieldset>
-          <form class="tawkto-widget-settings" action="" method="post" id="module_form" accept-charset="UTF-8">
-            <fieldset class="form-wrapper" id="visibility-settings">
-              <legend><span class="fieldset-legend">Visibility Settings</span></legend>
-              <div class="fieldset-wrapper">
-                <div class="fieldset-description">Define where the Tawk.to widget will and won't show</div>
-                <div class="form-item form-type-checkbox">
-                  <?php
-                    $checked = true;
-                    if (!is_null($display_opts)) {
-                      if (!$display_opts->always_display) {
-                        $checked = false;
-                      }
-                    }
-                  ?>
-                  <input type="checkbox" id="always_display" name="always_display" value="1" class="checkbox"
-                    <?php echo ($checked)?'checked':'';?> />
-                  <label class="option" for="always_display">Always show Tawk.To widget on every page</label>
-                  <div class="description">
-                    Select to show on all except the exceptions<br>
-                    De-select to select the specific pages
-                  </div>
-                </div>
-                <div class="form-item form-type-textarea div_hide_specific">
-                  <label for="hide_oncustom">Except on pages:</label>
-                  <div class="form-textarea-wrapper resizable textarea-processed resizable-textarea">
-                    <textarea class="form-textarea hide_specific" name="hide_oncustom" id="hide_oncustom" cols="40" rows="6"><?php if (!empty($display_opts->hide_oncustom)) {
-                            $whitelist = json_decode($display_opts->hide_oncustom);
-                            foreach ($whitelist as $page) { echo $page."\r\n"; }
-                    }?></textarea>
-                  </div>
-                  <div class="description">
-                    Add URLs to pages in which you would like to hide the widget.<br>
-                    Put each URL in a new line and just include the leading '/' and page URL (e.g. /about)
-                  </div>
-                </div>
-                <div class="form-item form-type-checkbox div_show_specific">
-                  <?php
-                    $checked = false;
-                    if (!is_null($display_opts)) {
-                      if ($display_opts->show_onfrontpage) {
-                        $checked = true;
-                      }
-                    }
-                  ?>
-                  <input type="checkbox" id="show_onfrontpage" name="show_onfrontpage" value="1" class="checkbox show_specific"
-                    <?php echo ($checked)?'checked':'';?> />
-                  <label class="option" for="show_onfrontpage">Show on front page</label>
-                </div>
-                <div class="form-item form-type-checkbox div_show_specific">
-                  <?php
-                    $checked = false;
-                    if (!is_null($display_opts)) {
-                      if ($display_opts->show_ontaxonomy) {
-                        $checked = true;
-                      }
-                    }
-                  ?>
-                  <input type="checkbox" id="show_ontaxonomy" name="show_ontaxonomy" value="1" class="checkbox show_specific"
-                    <?php echo ($checked)?'checked':'';?> />
-                  <label class="option" for="show_ontaxonomy">Show on taxonomy pages</label>
-                  <div class="description">
-                    Select to show on pages for taxonomy terms
-                  </div>
-                </div>
-                <div class="form-item form-type-textarea div_show_specific">
-                  <label for="hide_oncustom">Show on pages:</label>
-                  <div class="form-textarea-wrapper resizable textarea-processed resizable-textarea">
-                    <textarea class="form-textarea show_specific" name="show_oncustom" id="show_oncustom" cols="40" rows="6"><?php if (isset($display_opts->show_oncustom) && !empty($display_opts->show_oncustom)) {
-                        $whitelist = json_decode($display_opts->show_oncustom);
-                        foreach ($whitelist as $page) { echo $page."\r\n"; }
-                    }?></textarea>
-                    <div class="description">
-                      Add URLs to pages in which you would like to show the widget.<br>
-                      Put each URL in a new line and just include the the leading '/' and page URL (e.g. /about)
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </fieldset>
-            <fieldset class="form-wrapper" id="privacy-settings">
-              <legend><span class="fieldset-legend">Privacy Settings</span></legend>
-              <div class="fieldset-wrapper">
-                <div class="fieldset-description">Define whether or not user information can be used</div>
-                <div class="form-item form-type-checkbox">
-                  <?php
-                    $checked = 'checked';
-                    if (!is_null($display_opts) && !$display_opts->enable_visitor_recognition) {
-                      $checked = '';
-                    }
-                  ?>
-                  <input type="checkbox" class="checkbox" name="enable_visitor_recognition" id="enable_visitor_recognition" value="1"
-                    <?php echo $checked ?> />
-                  <label class="option" for="enable_visitor_recognition">Enable visitor recognition</label>
-                  <div class="description">
-                    If selected, name and email address from logged in users will be used to identify the user to you when a chat comes in via tawk.to
-                  </div>
-                </div>
-              </div>
-            </fieldset>
-            <div class="form-actions" id="edit-actions">
-              <input class="button-primary form-submit" type="submit" id="module_form_submit_btn" name="submitBlockCategories" value="Save configuration">
-            </div>
-          </form>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<script type="text/javascript">
-  var currentHost = window.location.protocol + "//" + window.location.host;
-  var url = "<?php echo $iframe_url; ?>&pltf=backdrop&parentDomain=" + currentHost;
-  jQuery("#tawkIframe").attr("src", url);
-
-  var iframe = jQuery("#tawk_widget_customization")[0];
-
-  window.addEventListener("message", function(e) {
-    if (e.origin === "<?php echo $base_url; ?>") {
-      if (e.data.action === "setWidget") {
-        setWidget(e);
-      }
-
-      if (e.data.action === "removeWidget") {
-        removeWidget(e);
-      }
-
-      if (e.data.action === 'reloadHeight') {
-        reloadIframeHeight(e.data.height);
-      }
-    }
-  });
-
-  function setWidget(e) {
-    jQuery.post("/admin/config/tawk/setwidget", {
-      pageId : e.data.pageId,
-      widgetId : e.data.widgetId
-    }, function(r) {
-      if (r.success) {
-        $('input[name="page_id"]').val(e.data.pageId);
-        $('input[name="widget_id"]').val(e.data.widgetId);
-        $('#widget_already_set').hide();
-        e.source.postMessage({action: "setDone"}, "<?php echo $base_url; ?>");
-      } else {
-        e.source.postMessage({action: "setFail"}, "<?php echo $base_url; ?>");
-      }
-    });
+  if ($display_opts && !empty($display_opts)) {
+    $display_opts = json_decode($display_opts);
+  }
+  else {
+    $display_opts = null;
   }
 
-  function removeWidget(e) {
-    jQuery.post("/admin/config/tawk/removewidget", function(r) {
-      if (r.success) {
-        $('input[name="page_id"]').val('');
-        $('input[name="widget_id"]').val('');
-        $('#widget_already_set').hide();
-        e.source.postMessage({action: "removeDone"}, "<?php echo $base_url; ?>");
-      } else {
-        e.source.postMessage({action: "removeFail"}, "<?php echo $base_url; ?>");
-      }
-    });
+  // visibility settings
+  $form['visibility_settings'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Visibility Settings'),
+    '#description' => t('Define where the tawk.to widget will and won\'t show')
+  );
+
+  // always display config
+  $always_display_attr = array();
+  if (!is_null($display_opts) && $display_opts->always_display) {
+    $always_display_attr['checked'] = true;
   }
 
-  function reloadIframeHeight(height) {
-    if (!height) {
-      return;
-    }
+  $form['visibility_settings']['always_display'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Always show Tawk.To widget on every page'),
+    '#description' => t('Select to show on all except the exceptions
+    De-select to select the specific pages'),
+    '#id' => t('always_display'),
+    '#attributes' => $always_display_attr
+  );
 
-    var iframe = jQuery('#tawkIframe');
-    if (height === iframe.height()) {
-      return;
-    }
+  // exclude url config
+  $form['visibility_settings']['hide_oncustom'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Except on pages:'),
+    '#description' => t('Add URLs to pages in which you would like to hide the widget.<br>
+    Put each URL in a new line and just include the leading \'/\' and page URL (e.g. /about)'),
+    '#prefix' => '<div class="div_hide_specific">',
+    '#suffix' => '</div>',
+    '#id' => t('hide_oncustom'),
+    '#default_value' => !is_null($display_opts) && $display_opts->hide_oncustom ?
+      format_multiline_url_paths($display_opts->hide_oncustom) : ''
+  );
 
-    iframe.height(height);
+  // show on front page config
+  $show_onfrontpage_attr = array();
+  if (!is_null($display_opts) && $display_opts->show_onfrontpage) {
+    $show_onfrontpage_attr['checked'] = true;
   }
 
-  jQuery(document).ready(function() {
-    if (jQuery("#always_display").prop("checked")) {
-      jQuery('.show_specific').prop('disabled', true);
-      jQuery(".div_show_specific").hide();
-    } else {
-      jQuery('.hide_specific').prop('disabled', true);
-      jQuery(".div_hide_specific").hide();
+  $form['visibility_settings']['show_onfrontpage'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Show on front page'),
+    '#prefix' => '<div class="div_show_specific">',
+    '#suffix' => '</div>',
+    '#id' => t('show_onfrontpage'),
+    '#attributes' => $show_onfrontpage_attr
+  );
+
+  // show on taxonomy config
+  $show_ontaxonomy_attr = array();
+  if (!is_null($display_opts) && $display_opts->show_ontaxonomy) {
+    $show_ontaxonomy_attr['checked'] = true;
+  }
+
+  $form['visibility_settings']['show_ontaxonomy'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Show on taxonomy pages'),
+    '#description' => t('Select to show on pages for taxonomy terms'),
+    '#prefix' => '<div class="div_show_specific">',
+    '#suffix' => '</div>',
+    '#id' => t('show_ontaxonomy'),
+    '#attributes' => $show_ontaxonomy_attr
+  );
+
+  // include urls config
+  $show_oncustom_default_value = '';
+  if (!is_null($display_opts) && $display_opts->show_oncustom) {
+    $show_oncustom_default_value = format_multiline_url_paths($display_opts->show_oncustom);
+  }
+  $form['visibility_settings']['show_oncustom'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Show on pages:'),
+    '#description' => t('Add URLs to pages in which you would like to show the widget.<br>
+    Put each URL in a new line and just include the the leading \'/\' and page URL (e.g. /about)'),
+    '#prefix' => '<div class="div_show_specific">',
+    '#suffix' => '</div>',
+    '#id' => t('show_oncustom'),
+    '#default_value' =>  $show_oncustom_default_value
+  );
+
+  // privacy settings
+  $form['privacy_settings'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Privacy Settings'),
+    '#description' => t('Define whether or not user information can be used')
+  );
+
+  // enable visitor recognition config
+  $enable_visitor_recognition_attr = array();
+  if (!is_null($display_opts) && $display_opts->enable_visitor_recognition) {
+    $enable_visitor_recognition_attr['checked'] = true;
+  }
+  $form['privacy_settings']['enable_visitor_recognition'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable visitor recognition'),
+    '#description' => t('If selected, name and email address from logged in users will be used to identify the user to you when a chat comes in via tawk.to'),
+    '#id' => t('enable_visitor_recognition'),
+    '#attributes' => $enable_visitor_recognition_attr
+  );
+
+  // submit button
+  $form['actions']['#type'] = 'actions';
+  $form['actions']['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save configuration'),
+  );
+
+  $form['#submit'][] = 'tawk_to_visibility_opts_form_submit';
+
+  return $form;
+}
+
+/**
+ * tawk.to visibility options form submit handler
+ */
+function tawk_to_visibility_opts_form_submit($form, &$form_state) {
+  $jsonOpts = array(
+    'always_display' => false,
+    'hide_oncustom' => array(),
+    'show_onfrontpage' => false,
+    'show_ontaxonomy' => false,
+    'show_oncustom' => array(),
+    'enable_visitor_recognition' => false
+  );
+
+  $options = $form_state['values'];
+
+  foreach ($options as $column => $value) {
+    switch ($column) {
+      case 'hide_oncustom':
+      case 'show_oncustom':
+        // replace newlines and returns with comma, and convert to array for saving
+        $value = str_replace(["\r\n", "\r", "\n"], ',', $value);
+        $value = explode(',', $value);
+        $value = (empty($value)||!$value)?array():$value;
+        $jsonOpts[$column] = json_encode($value);
+        break;
+      case 'show_onfrontpage':
+      case 'show_ontaxonomy':
+      case 'always_display':
+      case 'enable_visitor_recognition':
+        $jsonOpts[$column] = $value == 1;
+        break;
+    }
+  }
+
+  config_set(TAWK_TO_CONFIG_NAME, TAWK_TO_WIDGET_OPTIONS, json_encode($jsonOpts));
+
+  // Flush page cache so widget options will update at next page load
+  cache_flush('page');
+
+  backdrop_set_message('Successfully set widget options to your site');
+}
+
+/**
+ * Helper function to add new lines to url paths for displaying in textarea fields
+ */
+function format_multiline_url_paths($url_paths) {
+  $paths = json_decode($url_paths);
+  $formatted_paths = '';
+  foreach($paths as $path) {
+    if (!empty($formatted_paths)) {
+      $formatted_paths .= "\r\n";
     }
 
-    jQuery("#always_display").change(function() {
-      if (this.checked) {
-        jQuery('.hide_specific').prop('disabled', false);
-        jQuery('.show_specific').prop('disabled', true);
-        jQuery(".div_hide_specific").show();
-        jQuery(".div_show_specific").hide();
-      } else {
-        jQuery('.hide_specific').prop('disabled', true);
-        jQuery('.show_specific').prop('disabled', false);
-        jQuery(".div_hide_specific").hide();
-        jQuery(".div_show_specific").show();
-      }
-    });
-
-    // process the form
-    jQuery('#module_form').submit(function(event) {
-      $path = "/admin/config/tawk/setoptions";
-      jQuery.post($path, {
-        action : 'set_visibility',
-        ajax : true,
-        page_id : jQuery('input[name="page_id"]').val(),
-        widget_id : jQuery('input[name="widget_id"]').val(),
-        options : jQuery(this).serialize()
-      }, function(r) {
-        if (r.success) {
-          document.body.scrollTop = 0; // For Safari
-          document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
-          jQuery('#optionsSuccessMessage').toggle().delay(10000).fadeOut();
-        }
-      });
-
-      // stop the form from submitting the normal way and refreshing the page
-      event.preventDefault();
-    });
-  });
-</script>
-
-<?php
-  $markup = ob_get_contents();
-  ob_end_clean();
-  return $markup;
+    $formatted_paths .= $path;
+  }
+  return $formatted_paths;
 }

--- a/tawk_to.admin.inc
+++ b/tawk_to.admin.inc
@@ -1,260 +1,267 @@
 <?php
 /**
-* @file
-* @package   tawk.to module for Backdrop CMS
-* @copyright (C) 2021 tawk.to
-* @license   GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
-*/
+ * @file
+ * @package   tawk.to module for Backdrop CMS
+ * @copyright (C) 2021 tawk.to
+ * @license   GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
 
 /**
 * Creates markup for settings page.
 */
 function tawk_to_render_widget_iframe($base_url, $iframe_url, $widget=array(), $display_opts = null, $sameUser = true)
-{   ob_start();
-    ?><div id="content" >
-        <div class="l-wrapper">
-            <div class="l-wrapper-inner container container-fluid">
-                <div class="l-messages success-message-container" role="status" aria-label="Status messages" id="optionsSuccessMessage">
-                    <div class="messages status">
-                        <h2 class="element-invisible">Status message</h2>
-                        Successfully set widget options to your site
-                    </div>
-                </div>
-                <div class="l-page-title">
-                    <a id="main-content"></a>
-                </div>
-                <div class="l-content" role="main" aria-label="Main content">
-                    <div>
-                        <fieldset class="form-wrapper" id="property-widget-settings">
-                            <legend><span class="fieldset-legend">Property and Widget Selection</span></legend>
-                            <div class="fieldset-wrapper">
-                                <div class="fieldset-description">Select the property and widget from your tawk.to account</div>
-                                <?php if (!$sameUser) { ?>
-                                    <div id="widget_already_set" class="alert alert-warning">Notice: Widget already set by other user</div>
-                                <?php } ?>
-                                <iframe id="tawkIframe" class="tawkto-property-widget-selection" src="" ></iframe>
-                                <input type="hidden" class="hidden" name="page_id" value="<?php echo $widget['page_id']?>">
-                                <input type="hidden" class="hidden" name="widget_id" value="<?php echo $widget['widget_id']?>">
-                            </div>
-                        </fieldset>
-                        <form class="tawkto-widget-settings" action="" method="post" id="module_form" accept-charset="UTF-8">
-                            <fieldset class="form-wrapper" id="visibility-settings">
-                                <legend><span class="fieldset-legend">Visibility Settings</span></legend>
-                                <div class="fieldset-wrapper">
-                                    <div class="fieldset-description">Define where the Tawk.to widget will and won't show</div>
-                                    <div class="form-item form-type-checkbox">
-                                        <?php
-                                            $checked = true;
-                                            if (!is_null($display_opts)) {
-                                                if (!$display_opts->always_display) {
-                                                    $checked = false;
-                                                }
-                                            }
-                                        ?>
-                                        <input type="checkbox" id="always_display" name="always_display" value="1" class="checkbox" 
-                                            <?php echo ($checked)?'checked':'';?> />
-                                        <label class="option" for="always_display">Always show Tawk.To widget on every page</label>
-                                        <div class="description">
-                                            Select to show on all except the exceptions<br>
-                                            De-select to select the specific pages
-                                        </div>
-                                    </div>
-                                    <div class="form-item form-type-textarea div_hide_specific">
-                                        <label for="hide_oncustom">Except on pages:</label>
-                                        <div class="form-textarea-wrapper resizable textarea-processed resizable-textarea">
-                                            <textarea class="form-textarea hide_specific" name="hide_oncustom" id="hide_oncustom" cols="40" rows="6"><?php if (!empty($display_opts->hide_oncustom)) {
-                                                    $whitelist = json_decode($display_opts->hide_oncustom);                                                     
-                                                    foreach ($whitelist as $page) { echo $page."\r\n"; }
-                                            }?></textarea>
-                                        </div>
-                                        <div class="description">
-                                            Add URLs to pages in which you would like to hide the widget.<br>
-                                            Put each URL in a new line and just include the leading '/' and page URL (e.g. /about)
-                                        </div>
-                                    </div>
-                                    <div class="form-item form-type-checkbox div_show_specific">
-                                        <?php
-                                            $checked = false;
-                                            if (!is_null($display_opts)) {
-                                                if ($display_opts->show_onfrontpage) {
-                                                    $checked = true;
-                                                }
-                                            }
-                                        ?>
-                                        <input type="checkbox" id="show_onfrontpage" name="show_onfrontpage" value="1" class="checkbox show_specific" 
-                                            <?php echo ($checked)?'checked':'';?> />
-                                        <label class="option" for="show_onfrontpage">Show on front page</label>
-                                    </div>
-                                    <div class="form-item form-type-checkbox div_show_specific">
-                                        <?php
-                                            $checked = false;
-                                            if (!is_null($display_opts)) {
-                                                if ($display_opts->show_ontaxonomy) {
-                                                    $checked = true;
-                                                }
-                                            }
-                                        ?>
-                                        <input type="checkbox" id="show_ontaxonomy" name="show_ontaxonomy" value="1" class="checkbox show_specific" 
-                                            <?php echo ($checked)?'checked':'';?> />
-                                        <label class="option" for="show_ontaxonomy">Show on taxonomy pages</label>
-                                        <div class="description">
-                                            Select to show on pages for taxonomy terms
-                                        </div>
-                                    </div>
-                                    <div class="form-item form-type-textarea div_show_specific">
-                                        <label for="hide_oncustom">Show on pages:</label>
-                                        <div class="form-textarea-wrapper resizable textarea-processed resizable-textarea">
-                                            <textarea class="form-textarea show_specific" name="show_oncustom" id="show_oncustom" cols="40" rows="6"><?php if (isset($display_opts->show_oncustom) && !empty($display_opts->show_oncustom)) {
-                                                $whitelist = json_decode($display_opts->show_oncustom);
-                                                foreach ($whitelist as $page) { echo $page."\r\n"; }
-                                            }?></textarea>
-                                            <div class="description">
-                                                Add URLs to pages in which you would like to show the widget.<br>
-                                                Put each URL in a new line and just include the the leading '/' and page URL (e.g. /about)
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </fieldset>
-                            <fieldset class="form-wrapper" id="privacy-settings">
-                                <legend><span class="fieldset-legend">Privacy Settings</span></legend>
-                                <div class="fieldset-wrapper">
-                                    <div class="fieldset-description">Define whether or not user information can be used</div>
-                                    <div class="form-item form-type-checkbox">
-                                        <?php
-                                            $checked = 'checked';
-                                            if (!is_null($display_opts) && !$display_opts->enable_visitor_recognition) {
-                                                $checked = '';
-                                            }
-                                        ?>
-                                        <input type="checkbox" class="checkbox" name="enable_visitor_recognition" id="enable_visitor_recognition" value="1"
-                                            <?php echo $checked ?> />
-                                        <label class="option" for="enable_visitor_recognition">Enable visitor recognition</label>
-                                        <div class="description">
-                                            If selected, name and email address from logged in users will be used to identify the user to you when a chat comes in via tawk.to
-                                        </div>
-                                    </div>  
-                                </div>
-                            </fieldset>
-                            <div class="form-actions" id="edit-actions">
-                                <input class="button-primary form-submit" type="submit" id="module_form_submit_btn" name="submitBlockCategories" value="Save configuration">
-                            </div>                      
-                        </form>
-                    </div>
-                </div>
-            </div>
+{
+  ob_start();
+?>
+
+<div id="content" >
+  <div class="l-wrapper">
+    <div class="l-wrapper-inner container container-fluid">
+      <div class="l-messages success-message-container" role="status" aria-label="Status messages" id="optionsSuccessMessage">
+        <div class="messages status">
+          <h2 class="element-invisible">Status message</h2>
+          Successfully set widget options to your site
         </div>
-    </div>
-    <script type="text/javascript">
-        var currentHost = window.location.protocol + "//" + window.location.host;
-        var url = "<?php echo $iframe_url; ?>&pltf=backdrop&parentDomain=" + currentHost;
-        jQuery("#tawkIframe").attr("src", url);
-        var iframe = jQuery("#tawk_widget_customization")[0];
-        window.addEventListener("message", function(e) {
-            if(e.origin === "<?php echo $base_url; ?>") {
-                if(e.data.action === "setWidget") {
-                    setWidget(e);
-                }
-
-                if(e.data.action === "removeWidget") {
-                removeWidget(e);
-                }
-
-                if(e.data.action === 'reloadHeight') {
-                reloadIframeHeight(e.data.height);
-                }
-            }
-        });
-
-        function setWidget(e) {
-            jQuery.post("/admin/config/tawk/setwidget", {
-                pageId : e.data.pageId,
-                widgetId : e.data.widgetId
-                }, function(r) {
-                if(r.success) {
-                    $('input[name="page_id"]').val(e.data.pageId);
-                    $('input[name="widget_id"]').val(e.data.widgetId);
-                    $('#widget_already_set').hide();
-                    e.source.postMessage({action: "setDone"}, "<?php echo $base_url; ?>");
-                } else {
-                    e.source.postMessage({action: "setFail"}, "<?php echo $base_url; ?>");
-                }
-            });
-        }
-
-        function removeWidget(e) {
-            jQuery.post("/admin/config/tawk/removewidget", function(r) {
-                if(r.success) {
-                    $('input[name="page_id"]').val('');
-                    $('input[name="widget_id"]').val('');
-                    $('#widget_already_set').hide();
-                    e.source.postMessage({action: "removeDone"}, "<?php echo $base_url; ?>");
-                } else {
-                    e.source.postMessage({action: "removeFail"}, "<?php echo $base_url; ?>");
-                }
-            });
-        }
-
-        function reloadIframeHeight(height) {
-            if (!height) {
-                return;
-            }
-
-            var iframe = jQuery('#tawkIframe');
-            if (height === iframe.height()) {
-                return;
-            }
-
-            iframe.height(height);
-        }
-
-        jQuery(document).ready(function() {
-            if(jQuery("#always_display").prop("checked")){
-                jQuery('.show_specific').prop('disabled', true);
-                jQuery(".div_show_specific").hide();
-            } else {
-                jQuery('.hide_specific').prop('disabled', true);
-                jQuery(".div_hide_specific").hide();
-            }
-
-            jQuery("#always_display").change(function() {
-                if(this.checked){
-                    jQuery('.hide_specific').prop('disabled', false);
-                    jQuery('.show_specific').prop('disabled', true);
-                    jQuery(".div_hide_specific").show();
-                    jQuery(".div_show_specific").hide();
-                } else {
-                    jQuery('.hide_specific').prop('disabled', true);
-                    jQuery('.show_specific').prop('disabled', false);
-                    jQuery(".div_hide_specific").hide();
-                    jQuery(".div_show_specific").show();
-                }
-            });
-
-            // process the form
-            jQuery('#module_form').submit(function(event) {
-                $path = "/admin/config/tawk/setoptions";
-                jQuery.post($path, {
-                    action     : 'set_visibility',
-                    ajax       : true,
-                    page_id    : jQuery('input[name="page_id"]').val(),
-                    widget_id  : jQuery('input[name="widget_id"]').val(),
-                    options    : jQuery(this).serialize()
-                }, function(r) {
-                    if(r.success) {
-                        document.body.scrollTop = 0; // For Safari
-                        document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
-                        jQuery('#optionsSuccessMessage').toggle().delay(10000).fadeOut();
+      </div>
+      <div class="l-page-title">
+        <a id="main-content"></a>
+      </div>
+      <div class="l-content" role="main" aria-label="Main content">
+        <div>
+          <fieldset class="form-wrapper" id="property-widget-settings">
+            <legend><span class="fieldset-legend">Property and Widget Selection</span></legend>
+            <div class="fieldset-wrapper">
+              <div class="fieldset-description">Select the property and widget from your tawk.to account</div>
+              <?php if (!$sameUser) { ?>
+                <div id="widget_already_set" class="alert alert-warning">Notice: Widget already set by other user</div>
+              <?php } ?>
+              <iframe id="tawkIframe" class="tawkto-property-widget-selection" src="" ></iframe>
+              <input type="hidden" class="hidden" name="page_id" value="<?php echo $widget['page_id']?>">
+              <input type="hidden" class="hidden" name="widget_id" value="<?php echo $widget['widget_id']?>">
+            </div>
+          </fieldset>
+          <form class="tawkto-widget-settings" action="" method="post" id="module_form" accept-charset="UTF-8">
+            <fieldset class="form-wrapper" id="visibility-settings">
+              <legend><span class="fieldset-legend">Visibility Settings</span></legend>
+              <div class="fieldset-wrapper">
+                <div class="fieldset-description">Define where the Tawk.to widget will and won't show</div>
+                <div class="form-item form-type-checkbox">
+                  <?php
+                    $checked = true;
+                    if (!is_null($display_opts)) {
+                      if (!$display_opts->always_display) {
+                        $checked = false;
+                      }
                     }
-                });
+                  ?>
+                  <input type="checkbox" id="always_display" name="always_display" value="1" class="checkbox"
+                    <?php echo ($checked)?'checked':'';?> />
+                  <label class="option" for="always_display">Always show Tawk.To widget on every page</label>
+                  <div class="description">
+                    Select to show on all except the exceptions<br>
+                    De-select to select the specific pages
+                  </div>
+                </div>
+                <div class="form-item form-type-textarea div_hide_specific">
+                  <label for="hide_oncustom">Except on pages:</label>
+                  <div class="form-textarea-wrapper resizable textarea-processed resizable-textarea">
+                    <textarea class="form-textarea hide_specific" name="hide_oncustom" id="hide_oncustom" cols="40" rows="6"><?php if (!empty($display_opts->hide_oncustom)) {
+                            $whitelist = json_decode($display_opts->hide_oncustom);
+                            foreach ($whitelist as $page) { echo $page."\r\n"; }
+                    }?></textarea>
+                  </div>
+                  <div class="description">
+                    Add URLs to pages in which you would like to hide the widget.<br>
+                    Put each URL in a new line and just include the leading '/' and page URL (e.g. /about)
+                  </div>
+                </div>
+                <div class="form-item form-type-checkbox div_show_specific">
+                  <?php
+                    $checked = false;
+                    if (!is_null($display_opts)) {
+                      if ($display_opts->show_onfrontpage) {
+                        $checked = true;
+                      }
+                    }
+                  ?>
+                  <input type="checkbox" id="show_onfrontpage" name="show_onfrontpage" value="1" class="checkbox show_specific"
+                    <?php echo ($checked)?'checked':'';?> />
+                  <label class="option" for="show_onfrontpage">Show on front page</label>
+                </div>
+                <div class="form-item form-type-checkbox div_show_specific">
+                  <?php
+                    $checked = false;
+                    if (!is_null($display_opts)) {
+                      if ($display_opts->show_ontaxonomy) {
+                        $checked = true;
+                      }
+                    }
+                  ?>
+                  <input type="checkbox" id="show_ontaxonomy" name="show_ontaxonomy" value="1" class="checkbox show_specific"
+                    <?php echo ($checked)?'checked':'';?> />
+                  <label class="option" for="show_ontaxonomy">Show on taxonomy pages</label>
+                  <div class="description">
+                    Select to show on pages for taxonomy terms
+                  </div>
+                </div>
+                <div class="form-item form-type-textarea div_show_specific">
+                  <label for="hide_oncustom">Show on pages:</label>
+                  <div class="form-textarea-wrapper resizable textarea-processed resizable-textarea">
+                    <textarea class="form-textarea show_specific" name="show_oncustom" id="show_oncustom" cols="40" rows="6"><?php if (isset($display_opts->show_oncustom) && !empty($display_opts->show_oncustom)) {
+                        $whitelist = json_decode($display_opts->show_oncustom);
+                        foreach ($whitelist as $page) { echo $page."\r\n"; }
+                    }?></textarea>
+                    <div class="description">
+                      Add URLs to pages in which you would like to show the widget.<br>
+                      Put each URL in a new line and just include the the leading '/' and page URL (e.g. /about)
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </fieldset>
+            <fieldset class="form-wrapper" id="privacy-settings">
+              <legend><span class="fieldset-legend">Privacy Settings</span></legend>
+              <div class="fieldset-wrapper">
+                <div class="fieldset-description">Define whether or not user information can be used</div>
+                <div class="form-item form-type-checkbox">
+                  <?php
+                    $checked = 'checked';
+                    if (!is_null($display_opts) && !$display_opts->enable_visitor_recognition) {
+                      $checked = '';
+                    }
+                  ?>
+                  <input type="checkbox" class="checkbox" name="enable_visitor_recognition" id="enable_visitor_recognition" value="1"
+                    <?php echo $checked ?> />
+                  <label class="option" for="enable_visitor_recognition">Enable visitor recognition</label>
+                  <div class="description">
+                    If selected, name and email address from logged in users will be used to identify the user to you when a chat comes in via tawk.to
+                  </div>
+                </div>
+              </div>
+            </fieldset>
+            <div class="form-actions" id="edit-actions">
+              <input class="button-primary form-submit" type="submit" id="module_form_submit_btn" name="submitBlockCategories" value="Save configuration">
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 
-                // stop the form from submitting the normal way and refreshing the page
-                event.preventDefault();
-            });
-        });
-    </script>
+<script type="text/javascript">
+  var currentHost = window.location.protocol + "//" + window.location.host;
+  var url = "<?php echo $iframe_url; ?>&pltf=backdrop&parentDomain=" + currentHost;
+  jQuery("#tawkIframe").attr("src", url);
+
+  var iframe = jQuery("#tawk_widget_customization")[0];
+
+  window.addEventListener("message", function(e) {
+    if (e.origin === "<?php echo $base_url; ?>") {
+      if (e.data.action === "setWidget") {
+        setWidget(e);
+      }
+
+      if (e.data.action === "removeWidget") {
+        removeWidget(e);
+      }
+
+      if (e.data.action === 'reloadHeight') {
+        reloadIframeHeight(e.data.height);
+      }
+    }
+  });
+
+  function setWidget(e) {
+    jQuery.post("/admin/config/tawk/setwidget", {
+      pageId : e.data.pageId,
+      widgetId : e.data.widgetId
+    }, function(r) {
+      if (r.success) {
+        $('input[name="page_id"]').val(e.data.pageId);
+        $('input[name="widget_id"]').val(e.data.widgetId);
+        $('#widget_already_set').hide();
+        e.source.postMessage({action: "setDone"}, "<?php echo $base_url; ?>");
+      } else {
+        e.source.postMessage({action: "setFail"}, "<?php echo $base_url; ?>");
+      }
+    });
+  }
+
+  function removeWidget(e) {
+    jQuery.post("/admin/config/tawk/removewidget", function(r) {
+      if (r.success) {
+        $('input[name="page_id"]').val('');
+        $('input[name="widget_id"]').val('');
+        $('#widget_already_set').hide();
+        e.source.postMessage({action: "removeDone"}, "<?php echo $base_url; ?>");
+      } else {
+        e.source.postMessage({action: "removeFail"}, "<?php echo $base_url; ?>");
+      }
+    });
+  }
+
+  function reloadIframeHeight(height) {
+    if (!height) {
+      return;
+    }
+
+    var iframe = jQuery('#tawkIframe');
+    if (height === iframe.height()) {
+      return;
+    }
+
+    iframe.height(height);
+  }
+
+  jQuery(document).ready(function() {
+    if (jQuery("#always_display").prop("checked")) {
+      jQuery('.show_specific').prop('disabled', true);
+      jQuery(".div_show_specific").hide();
+    } else {
+      jQuery('.hide_specific').prop('disabled', true);
+      jQuery(".div_hide_specific").hide();
+    }
+
+    jQuery("#always_display").change(function() {
+      if (this.checked) {
+        jQuery('.hide_specific').prop('disabled', false);
+        jQuery('.show_specific').prop('disabled', true);
+        jQuery(".div_hide_specific").show();
+        jQuery(".div_show_specific").hide();
+      } else {
+        jQuery('.hide_specific').prop('disabled', true);
+        jQuery('.show_specific').prop('disabled', false);
+        jQuery(".div_hide_specific").hide();
+        jQuery(".div_show_specific").show();
+      }
+    });
+
+    // process the form
+    jQuery('#module_form').submit(function(event) {
+      $path = "/admin/config/tawk/setoptions";
+      jQuery.post($path, {
+        action : 'set_visibility',
+        ajax : true,
+        page_id : jQuery('input[name="page_id"]').val(),
+        widget_id : jQuery('input[name="widget_id"]').val(),
+        options : jQuery(this).serialize()
+      }, function(r) {
+        if (r.success) {
+          document.body.scrollTop = 0; // For Safari
+          document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
+          jQuery('#optionsSuccessMessage').toggle().delay(10000).fadeOut();
+        }
+      });
+
+      // stop the form from submitting the normal way and refreshing the page
+      event.preventDefault();
+    });
+  });
+</script>
+
 <?php
-    $markup = ob_get_contents();
-    ob_end_clean();
-    return $markup;
+  $markup = ob_get_contents();
+  ob_end_clean();
+  return $markup;
 }

--- a/tawk_to.module
+++ b/tawk_to.module
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * @package   tawk.to module for Backdrop CMS
@@ -16,298 +15,300 @@ define('TAWK_TO_WIDGET_USER_ID', 'widget_user_id');
 define('TAWK_TO_CONFIG_NAME', 'tawk_to.settings');
 
 /**
- * Retrieves widget details from database.
- */
-function tawk_to_get_widget()
-{
-    return array(
-            'page_id' => config_get(TAWK_TO_CONFIG_NAME, TAWK_TO_PAGE_ID),
-            'widget_id' => config_get(TAWK_TO_CONFIG_NAME,TAWK_TO_WIDGET_ID),
-        );
+* Retrieves widget details from database.
+*/
+function tawk_to_get_widget() {
+  return array(
+    'page_id' => config_get(TAWK_TO_CONFIG_NAME, TAWK_TO_PAGE_ID),
+    'widget_id' => config_get(TAWK_TO_CONFIG_NAME,TAWK_TO_WIDGET_ID),
+  );
 }
 
 /**
- * Implements hook_preprocess_page().
- * Ensures widget appears on all defined pages
- */
-function tawk_to_preprocess_page(&$variables)
-{
-    global $base_url;
+* Implements hook_preprocess_page().
+* Ensures widget appears on all defined pages
+*/
+function tawk_to_preprocess_page(&$variables) {
+  global $base_url;
 
-    // backend checking; do not show chat widget on admin page(s)
-    if (path_is_admin(current_path())) {
+  // backend checking; do not show chat widget on admin page(s)
+  if (path_is_admin(current_path())) {
+    return;
+  }
+
+  $widget = tawk_to_get_widget();
+
+  if ($widget['page_id'] === '' || $widget['widget_id'] === '') {
+    return null;
+  }
+
+  $page_id = $widget['page_id'];
+  $widget_id = $widget['widget_id'];
+
+  // get visibility options
+  $options = config_get(TAWK_TO_CONFIG_NAME, TAWK_TO_WIDGET_OPTIONS);
+  $markupOptions = array(
+    'enable_visitor_recognition' => true, // default value
+  );
+
+  if ($options) {
+    $options = json_decode($options);
+
+    if (isset($options->enable_visitor_recognition)) {
+      $markupOptions['enable_visitor_recognition'] = $options->enable_visitor_recognition;
+    }
+
+    // prepare visibility
+    $currentUrl = $base_url.$_SERVER['REQUEST_URI'];
+
+    if (false==$options->always_display) {
+      $showPages = json_decode($options->show_oncustom);
+      $show = false;
+
+      foreach ($showPages as $slug) {
+        if ($currentUrl == $base_url.$slug) {
+          $show = true;
+          break;
+        }
+      }
+
+      // taxonomy term pages
+      if (arg(0) ==  'taxonomy' && arg(1) == 'term' && is_numeric(arg(2)) && arg(3) == '') {
+        if (false != $options->show_ontaxonomy) {
+          $show = true;
+        }
+      }
+
+      // front page
+      if (backdrop_is_front_page()) {
+        if (false != $options->show_onfrontpage) {
+          $show = true;
+        }
+      }
+
+      if (!$show) {
         return;
+      }
     }
+    else {
+      if (isset($options->hide_oncustom)) {
+        $hide_pages = json_decode($options->hide_oncustom);
+        $show = true;
 
-    $widget = tawk_to_get_widget();
+        $currentUrl = (string) $currentUrl;
+        foreach ($hide_pages as $slug) {
+          // we need to add htmlspecialchars due to slashes added when saving to database
+          $slug = (string) htmlspecialchars($slug);
+                    $slug = (string) htmlspecialchars($slug);
+          $slug = (string) htmlspecialchars($slug);
 
-    if ($widget['page_id'] === '' || $widget['widget_id'] === '') {
-        return null;
-    }
-    $page_id = $widget['page_id'];
-    $widget_id = $widget['widget_id'];
-
-    // get visibility options
-    $options = config_get(TAWK_TO_CONFIG_NAME, TAWK_TO_WIDGET_OPTIONS);
-    $markupOptions = array(
-        'enable_visitor_recognition' => true, // default value
-    );
-    if ($options) {
-        $options = json_decode($options);
-
-        if (isset($options->enable_visitor_recognition)) {
-            $markupOptions['enable_visitor_recognition'] = $options->enable_visitor_recognition;
-        }
-
-        // prepare visibility
-        $currentUrl = $base_url.$_SERVER["REQUEST_URI"];
-        if (false==$options->always_display) {
-
-            $showPages = json_decode($options->show_oncustom);
+          if ($currentUrl == $base_url.$slug) {
             $show = false;
-            foreach ($showPages as $slug) {
-                if ($currentUrl == $base_url.$slug) {
-                    $show = true;
-                    break;
-                }
-            }
-
-            // taxonomy term pages
-            if (arg(0) ==  "taxonomy" && arg(1) == "term" && is_numeric(arg(2)) && arg(3) == "") {
-                if (false != $options->show_ontaxonomy) {
-                    $show = true;
-                }
-            }
-            
-            // front page
-            if (backdrop_is_front_page()) {
-                if (false != $options->show_onfrontpage) {
-                    $show = true;
-                }
-            }
-
-            if (!$show) {
-                return;
-            }
-        } else {
-            if (isset($options->hide_oncustom)) {
-                $hide_pages = json_decode($options->hide_oncustom);
-                $show = true;
-
-                $currentUrl = (string) $currentUrl;
-                foreach ($hide_pages as $slug) {
-                    // we need to add htmlspecialchars due to slashes added when saving to database
-                    $slug = (string) htmlspecialchars($slug); 
-
-                    if ($currentUrl == $base_url.$slug) {
-                        $show = false;
-                        break;
-                    }
-                }
-
-                if (!$show) {
-                    return;
-                }
-            }
+            break;
+          }
         }
+
+        if (!$show) {
+          return;
+        }
+      }
     }
+  }
 
-    $variables['page_bottom'] .= tawk_to_render_widget($page_id, $widget_id, $markupOptions);
+  $variables['page_bottom'] .= tawk_to_render_widget($page_id, $widget_id, $markupOptions);
 
-    return $variables;
+  return $variables;
 }
 
 /**
- * Hooks up configuration menu items and paths for ajax call endpoints.
- */
-function tawk_to_menu()
-{
-
+* Hooks up configuration menu items and paths for ajax call endpoints.
+*/
+function tawk_to_menu() {
   $items = array();
   $items['admin/config/tawk'] = array(
-        'title'            => 'tawk.to',
-        'description'      => 'tawk.to configuration',
-        'position'         => 'left',
-        'weight'           => -100,
-        'page callback'    => 'system_admin_menu_block_page',
-        'access arguments' => array('administer site configuration'),
-        'file'             => 'system.admin.inc',
-        'file path'        => backdrop_get_path('module', 'system'),
-      );
+    'title'            => 'tawk.to',
+    'description'      => 'tawk.to configuration',
+    'position'         => 'left',
+    'weight'           => -100,
+    'page callback'    => 'system_admin_menu_block_page',
+    'access arguments' => array('administer site configuration'),
+    'file'             => 'system.admin.inc',
+    'file path'        => backdrop_get_path('module', 'system'),
+  );
 
   $items['admin/config/tawk/widget'] = array(
-        'title'            => 'Widget',
-        'description'      => 'Included tawk.to widget configuration',
-        'page callback'    => 'tawkto_widget_customization',
-        'access arguments' => array('administer site configuration'),
-        'type'             => MENU_NORMAL_ITEM,
-      );
+    'title'            => 'Widget',
+    'description'      => 'Included tawk.to widget configuration',
+    'page callback'    => 'tawkto_widget_customization',
+    'access arguments' => array('administer site configuration'),
+    'type'             => MENU_NORMAL_ITEM,
+  );
 
   $items['admin/config/tawk/setwidget'] = array(
-        'title'            => 'Set widget',
-        'page callback'    => 'tawk_to_set_widget',
-        'access arguments' => array('administer site configuration'),
-        'type'             => MENU_CALLBACK,
-      );
+    'title'            => 'Set widget',
+    'page callback'    => 'tawk_to_set_widget',
+    'access arguments' => array('administer site configuration'),
+    'type'             => MENU_CALLBACK,
+  );
 
   $items['admin/config/tawk/removewidget'] = array(
-        'title'            => 'Remove widget',
-        'page callback'    => 'tawk_to_remove_widget',
-        'access arguments' => array('administer site configuration'),
-        'type'             => MENU_CALLBACK,
-      );
+    'title'            => 'Remove widget',
+    'page callback'    => 'tawk_to_remove_widget',
+    'access arguments' => array('administer site configuration'),
+    'type'             => MENU_CALLBACK,
+  );
 
   $items['admin/config/tawk/setoptions'] = array(
-        'title'            => 'Set widget options',
-        'page callback'    => 'tawkto_widget_options',
-        'access arguments' => array('administer site configuration'),
-        'type'             => MENU_CALLBACK,
-      );
+    'title'            => 'Set widget options',
+    'page callback'    => 'tawkto_widget_options',
+    'access arguments' => array('administer site configuration'),
+    'type'             => MENU_CALLBACK,
+  );
 
   return $items;
 }
 
 /**
- * Displays widget configuration iframe.
- *
- * Configuration iframe contains functionality from
- * tawk.to server which is responsible for verifying
- * user login details and also retrieves the user's 
- * property and widget list and comunicates back to the
- * parent page so that changes can be saved in the config files.
- */
-function tawkto_widget_customization()
-{
-    $base_url = tawk_to_get_base_url();
-    $iframe_url = tawk_to_get_iframe_url();
-    $widget = tawk_to_get_widget();
+* Displays widget configuration iframe.
+*
+* Configuration iframe contains functionality from
+* tawk.to server which is responsible for verifying
+* user login details and also retrieves the user's
+ * user login details and also retrieves the user's
+* user login details and also retrieves the user's
+* property and widget list and comunicates back to the
+* parent page so that changes can be saved in the config files.
+*/
+function tawkto_widget_customization() {
+  $base_url = tawk_to_get_base_url();
+  $iframe_url = tawk_to_get_iframe_url();
+  $widget = tawk_to_get_widget();
 
-    global $user;
-    $sameUser = true;
-    $value = config_get(TAWK_TO_CONFIG_NAME, TAWK_TO_WIDGET_USER_ID);
-    if (!empty($value) && $user->uid!=$value) {
-        $sameUser = false;
-    }
+  global $user;
+  $sameUser = true;
+  $value = config_get(TAWK_TO_CONFIG_NAME, TAWK_TO_WIDGET_USER_ID);
 
-    $displayOpts = config_get(TAWK_TO_CONFIG_NAME, TAWK_TO_WIDGET_OPTIONS);
-    if ($displayOpts && !empty($displayOpts)) {
-        $displayOpts = json_decode($displayOpts);
-    } else {
-        $displayOpts = null;
-    }
+  if (!empty($value) && $user->uid!=$value) {
+    $sameUser = false;
+  }
 
-    $module_path = backdrop_get_path('module', 'tawk_to');
-    backdrop_add_css($module_path . '/css/tawk_to.admin.css', 'file');
+  $displayOpts = config_get(TAWK_TO_CONFIG_NAME, TAWK_TO_WIDGET_OPTIONS);
 
-    return tawk_to_render_widget_iframe($base_url, $iframe_url, $widget, $displayOpts, $sameUser);
+  if ($displayOpts && !empty($displayOpts)) {
+    $displayOpts = json_decode($displayOpts);
+  }
+  else {
+    $displayOpts = null;
+  }
+
+  $module_path = backdrop_get_path('module', 'tawk_to');
+  backdrop_add_css($module_path . '/css/tawk_to.admin.css', 'file');
+
+  return tawk_to_render_widget_iframe($base_url, $iframe_url, $widget, $displayOpts, $sameUser);
 }
 
 /**
- * Constructs url for configuration iframe.
- */
-function tawk_to_get_iframe_url()
-{
-    $widget = tawk_to_get_widget();
-    if (!$widget) {
-        $widget = array(
-                'page_id'   => '',
-                'widget_id' => '',
-            );
-    }
-    return tawk_to_get_base_url() . '/generic/widgets?currentWidgetId=' . $widget['widget_id'] . '&currentPageId=' . $widget['page_id'];
+* Constructs url for configuration iframe.
+*/
+function tawk_to_get_iframe_url() {
+  $widget = tawk_to_get_widget();
+
+  if (!$widget) {
+    $widget = array(
+      'page_id'   => '',
+      'widget_id' => '',
+    );
+  }
+  return tawk_to_get_base_url() . '/generic/widgets?currentWidgetId=' . $widget['widget_id'] . '&currentPageId=' . $widget['page_id'];
 }
 
 /**
- * Base url for tawk.to application which serves iframe.
- */
-function tawk_to_get_base_url()
-{
-    return 'https://plugins.tawk.to';
+* Base url for tawk.to application which serves iframe.
+*/
+function tawk_to_get_base_url() {
+  return 'https://plugins.tawk.to';
 }
 
 /**
- * Ajax endpoint which is used to set selected widget details.
- */
-function tawk_to_set_widget()
-{
+* Ajax endpoint which is used to set selected widget details.
+*/
+function tawk_to_set_widget() {
+  if (!isset($_POST['pageId']) || !isset($_POST['widgetId'])) {
+    return backdrop_json_output(array('success' => false));
+  }
 
-    if (!isset($_POST['pageId']) || !isset($_POST['widgetId'])) {
-        return backdrop_json_output(array('success' => false));
-    }
+  if (preg_match('/^[0-9A-Fa-f]{24}$/', $_POST['pageId']) !== 1 || preg_match('/^[a-z0-9]{1,50}$/i', $_POST['widgetId']) !== 1) {
+    return backdrop_json_output(array('success' => false));
+  }
 
-    if (preg_match('/^[0-9A-Fa-f]{24}$/', $_POST['pageId']) !== 1 || preg_match('/^[a-z0-9]{1,50}$/i', $_POST['widgetId']) !== 1) {
-        return backdrop_json_output(array('success' => false));
-    }
+  config_set(TAWK_TO_CONFIG_NAME, TAWK_TO_PAGE_ID, $_POST['pageId']);
+  config_set(TAWK_TO_CONFIG_NAME, TAWK_TO_WIDGET_ID, $_POST['widgetId']);
 
-    config_set(TAWK_TO_CONFIG_NAME, TAWK_TO_PAGE_ID, $_POST['pageId']);
-    config_set(TAWK_TO_CONFIG_NAME, TAWK_TO_WIDGET_ID, $_POST['widgetId']);
+  global $user;
+  if ($user->uid) {
+    config_set(TAWK_TO_CONFIG_NAME, TAWK_TO_WIDGET_USER_ID, $user->uid);
+  }
 
-    global $user;
-    if ($user->uid) {
-        config_set(TAWK_TO_CONFIG_NAME, TAWK_TO_WIDGET_USER_ID, $user->uid);
-    }
+  // Flush page cache so widget will appear at next page load
+  cache_flush('page');
 
-    // Flush page cache so widget will appear at next page load
-    cache_flush('page');
-    
-    backdrop_json_output(array('success' => true));
+  backdrop_json_output(array('success' => true));
 }
 
 /**
- * Ajax endpoint which is used to remove currently selected widget details.
- */
-function tawk_to_remove_widget($a = 0, $b = 0)
-{
-    $config = config(TAWK_TO_CONFIG_NAME);
-    $config->clear(TAWK_TO_PAGE_ID);
-    $config->clear(TAWK_TO_WIDGET_ID);
-    $config->save();
+* Ajax endpoint which is used to remove currently selected widget details.
+*/
+function tawk_to_remove_widget($a = 0, $b = 0) {
+  $config = config(TAWK_TO_CONFIG_NAME);
+  $config->clear(TAWK_TO_PAGE_ID);
+  $config->clear(TAWK_TO_WIDGET_ID);
+  $config->save();
 
-    // Flush page cache so widget will disappear at next page load
-    cache_flush('page');
-    
-    backdrop_json_output(array('success' => true));
+  // Flush page cache so widget will disappear at next page load
+  cache_flush('page');
+
+  backdrop_json_output(array('success' => true));
 }
 
-function tawkto_widget_options()
-{
-    $jsonOpts = array(
-            'always_display' => false,
-            'hide_oncustom' => array(),
-            'show_onfrontpage' => false,
-            'show_ontaxonomy' => false,
-            'show_onproduct' => false,
-            'show_oncustom' => array(),
-            'enable_visitor_recognition' => false
-        );
+function tawkto_widget_options() {
+  $jsonOpts = array(
+    'always_display' => false,
+    'hide_oncustom' => array(),
+    'show_onfrontpage' => false,
+    'show_ontaxonomy' => false,
+    'show_onproduct' => false,
+    'show_oncustom' => array(),
+    'enable_visitor_recognition' => false
+  );
 
-    if (isset($_REQUEST['options']) && !empty($_REQUEST['options'])) {
-        $options = explode('&', $_REQUEST['options']);
-        foreach ($options as $post) {
-            list($column, $value) = explode('=', $post);
-            switch ($column) {
-                case 'hide_oncustom':
-                case 'show_oncustom':
-                    // replace newlines and returns with comma, and convert to array for saving
-                    $value = urldecode($value);
-                    $value = str_ireplace(["\r\n", "\r", "\n"], ',', $value);
-                    $value = explode(",", $value);
-                    $value = (empty($value)||!$value)?array():$value;
-                    $jsonOpts[$column] = json_encode($value);
-                    break;
-
-                case 'show_onfrontpage':
-                case 'show_ontaxonomy':
-                case 'show_onproduct':
-                case 'always_display':
-                case 'enable_visitor_recognition':
-                    $jsonOpts[$column] = $value == 1;
-                    break;
-            }
-        }
+  if (isset($_REQUEST['options']) && !empty($_REQUEST['options'])) {
+    $options = explode('&', $_REQUEST['options']);
+    foreach ($options as $post) {
+      list($column, $value) = explode('=', $post);
+      switch ($column) {
+        case 'hide_oncustom':
+        case 'show_oncustom':
+          // replace newlines and returns with comma, and convert to array for saving
+          $value = urldecode($value);
+          $value = str_ireplace(['\r\n', '\r', '\n'], ',', $value);
+          $value = explode(',', $value);
+          $value = (empty($value)||!$value)?array():$value;
+          $jsonOpts[$column] = json_encode($value);
+          break;
+        case 'show_onfrontpage':
+        case 'show_ontaxonomy':
+        case 'show_onproduct':
+        case 'always_display':
+        case 'enable_visitor_recognition':
+          $jsonOpts[$column] = $value == 1;
+          break;
+      }
     }
-    config_set(TAWK_TO_CONFIG_NAME, TAWK_TO_WIDGET_OPTIONS, json_encode($jsonOpts));
-    // Flush page cache so widget options will update at next page load
-    cache_flush('page');
-    backdrop_json_output(array('success' => true));
+  }
+
+  config_set(TAWK_TO_CONFIG_NAME, TAWK_TO_WIDGET_OPTIONS, json_encode($jsonOpts));
+
+  // Flush page cache so widget options will update at next page load
+  cache_flush('page');
+  backdrop_json_output(array('success' => true));
 }

--- a/tawk_to.module
+++ b/tawk_to.module
@@ -139,7 +139,7 @@ function tawk_to_menu() {
   $items['admin/config/tawk/widget'] = array(
     'title'            => 'Widget',
     'description'      => 'Included tawk.to widget configuration',
-    'page callback'    => 'tawkto_widget_customization',
+    'page callback'    => 'tawk_to_admin_page',
     'access arguments' => array('administer site configuration'),
     'type'             => MENU_NORMAL_ITEM,
   );
@@ -158,32 +158,13 @@ function tawk_to_menu() {
     'type'             => MENU_CALLBACK,
   );
 
-  $items['admin/config/tawk/setoptions'] = array(
-    'title'            => 'Set widget options',
-    'page callback'    => 'tawkto_widget_options',
-    'access arguments' => array('administer site configuration'),
-    'type'             => MENU_CALLBACK,
-  );
-
   return $items;
 }
 
 /**
-* Displays widget configuration iframe.
-*
-* Configuration iframe contains functionality from
-* tawk.to server which is responsible for verifying
-* user login details and also retrieves the user's
- * user login details and also retrieves the user's
-* user login details and also retrieves the user's
-* property and widget list and comunicates back to the
-* parent page so that changes can be saved in the config files.
-*/
-function tawkto_widget_customization() {
-  $base_url = tawk_to_get_base_url();
-  $iframe_url = tawk_to_get_iframe_url();
-  $widget = tawk_to_get_widget();
-
+ * Implements tawk.to module admin page
+ */
+function tawk_to_admin_page() {
   global $user;
   $sameUser = true;
   $value = config_get(TAWK_TO_CONFIG_NAME, TAWK_TO_WIDGET_USER_ID);
@@ -192,19 +173,28 @@ function tawkto_widget_customization() {
     $sameUser = false;
   }
 
-  $displayOpts = config_get(TAWK_TO_CONFIG_NAME, TAWK_TO_WIDGET_OPTIONS);
+  $visibility_opts_form = backdrop_get_form('tawk_to_visibility_opts_form');
 
-  if ($displayOpts && !empty($displayOpts)) {
-    $displayOpts = json_decode($displayOpts);
-  }
-  else {
-    $displayOpts = null;
-  }
+  return theme('tawk_to_admin_page', array(
+    'base_url' => tawk_to_get_base_url(),
+    'iframe_url' => tawk_to_get_iframe_url(),
+    'widget' => tawk_to_get_widget(),
+    'sameUser' => $sameUser,
+    'visibility_opts_form' => render($visibility_opts_form)
+  ));
+}
 
-  $module_path = backdrop_get_path('module', 'tawk_to');
-  backdrop_add_css($module_path . '/css/tawk_to.admin.css', 'file');
-
-  return tawk_to_render_widget_iframe($base_url, $iframe_url, $widget, $displayOpts, $sameUser);
+/**
+ * Implements module theme hook for templates usage.
+ */
+function tawk_to_theme() {
+  return array(
+    'tawk_to_admin_page' => array(
+      'variables' => array('title' => NULL),
+      'template' => 'admin',
+      'path' => backdrop_get_path('module', 'tawk_to') . '/templates'
+    )
+  );
 }
 
 /**
@@ -267,48 +257,5 @@ function tawk_to_remove_widget($a = 0, $b = 0) {
   // Flush page cache so widget will disappear at next page load
   cache_flush('page');
 
-  backdrop_json_output(array('success' => true));
-}
-
-function tawkto_widget_options() {
-  $jsonOpts = array(
-    'always_display' => false,
-    'hide_oncustom' => array(),
-    'show_onfrontpage' => false,
-    'show_ontaxonomy' => false,
-    'show_onproduct' => false,
-    'show_oncustom' => array(),
-    'enable_visitor_recognition' => false
-  );
-
-  if (isset($_REQUEST['options']) && !empty($_REQUEST['options'])) {
-    $options = explode('&', $_REQUEST['options']);
-    foreach ($options as $post) {
-      list($column, $value) = explode('=', $post);
-      switch ($column) {
-        case 'hide_oncustom':
-        case 'show_oncustom':
-          // replace newlines and returns with comma, and convert to array for saving
-          $value = urldecode($value);
-          $value = str_ireplace(['\r\n', '\r', '\n'], ',', $value);
-          $value = explode(',', $value);
-          $value = (empty($value)||!$value)?array():$value;
-          $jsonOpts[$column] = json_encode($value);
-          break;
-        case 'show_onfrontpage':
-        case 'show_ontaxonomy':
-        case 'show_onproduct':
-        case 'always_display':
-        case 'enable_visitor_recognition':
-          $jsonOpts[$column] = $value == 1;
-          break;
-      }
-    }
-  }
-
-  config_set(TAWK_TO_CONFIG_NAME, TAWK_TO_WIDGET_OPTIONS, json_encode($jsonOpts));
-
-  // Flush page cache so widget options will update at next page load
-  cache_flush('page');
   backdrop_json_output(array('success' => true));
 }

--- a/tawk_to.module
+++ b/tawk_to.module
@@ -99,8 +99,6 @@ function tawk_to_preprocess_page(&$variables) {
         foreach ($hide_pages as $slug) {
           // we need to add htmlspecialchars due to slashes added when saving to database
           $slug = (string) htmlspecialchars($slug);
-                    $slug = (string) htmlspecialchars($slug);
-          $slug = (string) htmlspecialchars($slug);
 
           if ($currentUrl == $base_url.$slug) {
             $show = false;
@@ -180,7 +178,7 @@ function tawk_to_admin_page() {
     'iframe_url' => tawk_to_get_iframe_url(),
     'widget' => tawk_to_get_widget(),
     'sameUser' => $sameUser,
-    'visibility_opts_form' => render($visibility_opts_form)
+    'visibility_opts_form' => render($visibility_opts_form),
   ));
 }
 
@@ -192,7 +190,7 @@ function tawk_to_theme() {
     'tawk_to_admin_page' => array(
       'variables' => array('title' => NULL),
       'template' => 'admin',
-      'path' => backdrop_get_path('module', 'tawk_to') . '/templates'
+      'path' => backdrop_get_path('module', 'tawk_to') . '/templates',
     )
   );
 }

--- a/tawk_to.widget.inc
+++ b/tawk_to.widget.inc
@@ -9,15 +9,13 @@
 /**
  * Creates markup for embed script element.
  */
-function tawk_to_render_widget($page_id, $widget_id, $options)
-{
+function tawk_to_render_widget($page_id, $widget_id, $options) {
   global $user;
   $apiString = '';
-  if ($GLOBALS['user']->uid && $options['enable_visitor_recognition']) {
-    global $user;
+  if ($user->uid && $options['enable_visitor_recognition']) {
     $apiString = '$_Tawk_API.visitor = {
-      name  : "'.$user->name.'",
-      email : "'.$user->mail.'",
+      name  : "' . $user->name . '",
+      email : "' . $user->mail . '",
     };';
   }
 

--- a/tawk_to.widget.inc
+++ b/tawk_to.widget.inc
@@ -11,40 +11,43 @@
  */
 function tawk_to_render_widget($page_id, $widget_id, $options)
 {
+  global $user;
+  $apiString = '';
+  if ($GLOBALS['user']->uid && $options['enable_visitor_recognition']) {
     global $user;
-    $apiString = '';
-    if ($GLOBALS['user']->uid && $options['enable_visitor_recognition']) {
-        global $user;
-        $apiString = '$_Tawk_API.visitor = {
-            name  : "'.$user->name.'",
-            email : "'.$user->mail.'",
-        };';
+    $apiString = '$_Tawk_API.visitor = {
+      name  : "'.$user->name.'",
+      email : "'.$user->mail.'",
+    };';
+  }
+
+  ob_start();
+?>
+<!--Start of tawk.to Script-->
+<script type="text/javascript">
+  var $_Tawk_API={},$_Tawk_LoadStart=new Date();
+  (function(){
+    var s1=document.createElement("script"),s0=document.getElementsByTagName("script")[0];
+    s1.async=true;
+    s1.src="https://embed.tawk.to/<?php echo $page_id; ?>/<?php echo $widget_id; ?>";
+    s1.charset="UTF-8";
+    s1.setAttribute("crossorigin","*");
+    s0.parentNode.insertBefore(s1,s0);
+  })();
+
+  <?php echo $apiString; ?>
+  var curpage = window.location.href;
+  var hash = window.location.hash;
+  $_Tawk_API.onLoad = function() {
+    if (curpage.indexOf('admin/') != -1 || hash.indexOf('overlay')!= -1) {
+      Tawk_API.hideWidget();
     }
+  };
+</script>
+<!--End of tawk.to Script-->
 
-    ob_start();
-    ?><!--Start of tawk.to Script-->
-    <script type="text/javascript">
-        var $_Tawk_API={},$_Tawk_LoadStart=new Date();
-        (function(){
-            var s1=document.createElement("script"),s0=document.getElementsByTagName("script")[0];
-            s1.async=true;
-            s1.src="https://embed.tawk.to/<?php echo $page_id; ?>/<?php echo $widget_id; ?>";
-            s1.charset="UTF-8";
-            s1.setAttribute("crossorigin","*");
-            s0.parentNode.insertBefore(s1,s0);
-        })();
-    <?php echo $apiString; ?>
-
-        var curpage = window.location.href;
-        var hash = window.location.hash;
-        $_Tawk_API.onLoad = function(){
-            if (curpage.indexOf('admin/') != -1 || hash.indexOf('overlay')!= -1) {
-                Tawk_API.hideWidget();
-            }
-        };
-    </script><!--End of tawk.to Script-->
-    <?php
-    $markup = ob_get_contents();
-    ob_end_clean();
-    return $markup;
+<?php
+  $markup = ob_get_contents();
+  ob_end_clean();
+  return $markup;
 }

--- a/templates/admin.tpl.php
+++ b/templates/admin.tpl.php
@@ -1,0 +1,127 @@
+<?php
+$module_path = backdrop_get_path('module', 'tawk_to');
+backdrop_add_css($module_path . '/css/tawk_to.admin.css', 'file');
+?>
+
+<div id="content" >
+  <div class="l-wrapper">
+    <div class="l-wrapper-inner container container-fluid">
+      <div class="l-messages success-message-container" role="status" aria-label="Status messages" id="optionsSuccessMessage">
+        <div class="messages status">
+          <h2 class="element-invisible">Status message</h2>
+          Successfully set widget options to your site
+        </div>
+      </div>
+      <div class="l-page-title">
+        <a id="main-content"></a>
+      </div>
+      <div class="l-content" role="main" aria-label="Main content">
+        <div>
+          <fieldset class="form-wrapper" id="property-widget-settings">
+            <legend><span class="fieldset-legend">Property and Widget Selection</span></legend>
+            <div class="fieldset-wrapper">
+              <div class="fieldset-description">Select the property and widget from your tawk.to account</div>
+              <?php if (!$sameUser) { ?>
+                <div id="widget_already_set" class="alert alert-warning">Notice: Widget already set by other user</div>
+              <?php } ?>
+              <iframe id="tawkIframe" class="tawkto-property-widget-selection" src="" ></iframe>
+              <input type="hidden" class="hidden" name="page_id" value="<?php echo $widget['page_id']?>">
+              <input type="hidden" class="hidden" name="widget_id" value="<?php echo $widget['widget_id']?>">
+            </div>
+          </fieldset>
+		  <?php print $visibility_opts_form ?>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script type="text/javascript">
+  var currentHost = window.location.protocol + "//" + window.location.host;
+  var url = "<?php echo $iframe_url; ?>&pltf=backdrop&parentDomain=" + currentHost;
+  jQuery("#tawkIframe").attr("src", url);
+
+  var iframe = jQuery("#tawk_widget_customization")[0];
+
+  window.addEventListener("message", function(e) {
+    if (e.origin === "<?php echo $base_url; ?>") {
+      if (e.data.action === "setWidget") {
+        setWidget(e);
+      }
+
+      if (e.data.action === "removeWidget") {
+        removeWidget(e);
+      }
+
+      if (e.data.action === 'reloadHeight') {
+        reloadIframeHeight(e.data.height);
+      }
+    }
+  });
+
+  function setWidget(e) {
+    jQuery.post("?q=admin/config/tawk/setwidget", {
+      pageId : e.data.pageId,
+      widgetId : e.data.widgetId
+    }, function(r) {
+      if (r.success) {
+        $('input[name="page_id"]').val(e.data.pageId);
+        $('input[name="widget_id"]').val(e.data.widgetId);
+        $('#widget_already_set').hide();
+        e.source.postMessage({action: "setDone"}, "<?php echo $base_url; ?>");
+      } else {
+        e.source.postMessage({action: "setFail"}, "<?php echo $base_url; ?>");
+      }
+    });
+  }
+
+  function removeWidget(e) {
+    jQuery.post("?q=admin/config/tawk/removewidget", function(r) {
+      if (r.success) {
+        $('input[name="page_id"]').val('');
+        $('input[name="widget_id"]').val('');
+        $('#widget_already_set').hide();
+        e.source.postMessage({action: "removeDone"}, "<?php echo $base_url; ?>");
+      } else {
+        e.source.postMessage({action: "removeFail"}, "<?php echo $base_url; ?>");
+      }
+    });
+  }
+
+  function reloadIframeHeight(height) {
+    if (!height) {
+      return;
+    }
+
+    var iframe = jQuery('#tawkIframe');
+    if (height === iframe.height()) {
+      return;
+    }
+
+    iframe.height(height);
+  }
+
+  jQuery(document).ready(function() {
+    if (jQuery("#always_display").prop("checked")) {
+      jQuery('.show_specific').prop('disabled', true);
+      jQuery(".div_show_specific").hide();
+    } else {
+      jQuery('.hide_specific').prop('disabled', true);
+      jQuery(".div_hide_specific").hide();
+    }
+
+    jQuery("#always_display").change(function() {
+      if (this.checked) {
+        jQuery('.hide_specific').prop('disabled', false);
+        jQuery('.show_specific').prop('disabled', true);
+        jQuery(".div_hide_specific").show();
+        jQuery(".div_show_specific").hide();
+      } else {
+        jQuery('.hide_specific').prop('disabled', true);
+        jQuery('.show_specific').prop('disabled', false);
+        jQuery(".div_hide_specific").hide();
+        jQuery(".div_show_specific").show();
+      }
+    });
+  });
+</script>

--- a/templates/admin.tpl.php
+++ b/templates/admin.tpl.php
@@ -29,7 +29,7 @@ backdrop_add_css($module_path . '/css/tawk_to.admin.css', 'file');
               <input type="hidden" class="hidden" name="widget_id" value="<?php echo $widget['widget_id']?>">
             </div>
           </fieldset>
-		  <?php print $visibility_opts_form ?>
+          <?php print $visibility_opts_form ?>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This solves the comments of one of backdrop's contributors [here](https://github.com/backdrop-ops/contrib/issues/555#issuecomment-909784915)

- [x] The admin.inc file is problematic. Because there is a HTML FORM tag that was not generated via the Backdrop Form API, this page will expose a security risk to any site running this module. You might have a look at another Backdrop or Drupal 7 module to see how admin forms can be built and processed securely. Generally speaking, if you find yourself needing to use ob_get_contents() in Drupal or Backdrop, you're probably missing an easier way.
- [x] Wherever possible, strings should be wrapped in single quotes ' instead of double quotes " so they will be evaluated faster (PHP will not search the string for variable replacements if it uses single quotes)
- [x] Blank lines after the opening <?php tag can be removed if you want. The extra line breaks were required in Drupal because of the previous CVS version control system, but are not needed anymore.
- [x] According to Backdrops Coding Standards indentation should be 2 spaces, instead of 4. (this increases the number of characters before the 80 character wrap)
- [x] According to Backdrops Coding Standards the opening tag for a function should remain on the same line as the function definition. (this reduces line count)
- [x] According to Backdrops Coding Standards the else statement should appear on the line following the closing tag for the if statement that proceeds it, not the same line. (this makes adding or removing else statements a cleaner operation because no changes will be necessary to the if statement above)